### PR TITLE
Fix beacon time interval to match requirement

### DIFF
--- a/tasks/beacon/beacon.go
+++ b/tasks/beacon/beacon.go
@@ -57,7 +57,7 @@ func tickerInterval(c *config.Beacon) {
 }
 
 func validate(c *config.Beacon) error {
-	if c.Interval < (time.Duration(30) * time.Minute) {
+	if c.Interval < (time.Duration(10) * time.Minute) {
 		return errors.New("interval cannot be < 10m")
 	}
 


### PR DESCRIPTION
We require the beacon time to be less than ten minutes, but in fact in code we perform a comparison with thirty minutes. This fix introduces consistency.