### PR TITLE
Update aprsis.go PrintfLine

### DIFF
--- a/services/aprsis/aprsis.go
+++ b/services/aprsis/aprsis.go
@@ -138,7 +138,7 @@ func UploadRaw(s string) {
 		Connect(opts)
 	}
 
-	err := conn.PrintfLine(s)
+	err := conn.PrintfLine("%s", s)
 
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
This code causes problems when a % shows up in a Mic-E comment.

The first arg of PrintfLine is a format string, any '%' chars will cause problems. It is best to have a static first arg.

73,
Jay